### PR TITLE
Simplified Into<T> using a macro + minor cleanups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,4 @@ mod raft;
 
 pub use state_machine::StateMachine;
 pub use persistent_log::PersistentLog;
-pub use raft::Raft;
-
-#[cfg(test)]
-mod test {
-
-}
+pub use raft::{Raft, Candidate, Follower, Leader, RaftState};

--- a/src/persistent_log/mock.rs
+++ b/src/persistent_log/mock.rs
@@ -1,9 +1,6 @@
 use super::PersistentLog;
 
+#[derive(Default)]
 pub struct MockPersistentLog;
-impl MockPersistentLog {
-    pub fn new() -> Self {
-        MockPersistentLog
-    }
-}
+
 impl PersistentLog for MockPersistentLog {}

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2,80 +2,95 @@ use persistent_log::PersistentLog;
 use state_machine::StateMachine;
 
 pub struct Raft<L, M, S>
-where L: PersistentLog, M: StateMachine {
+    where L: PersistentLog, M: StateMachine
+{
     persistent_log: L,
     state_machine: M,
-    state: S,
+    state: ::std::marker::PhantomData<S>,
 }
 
-// Follower -> Candidate
-struct Follower;
-// Candidate -> (Follower|Leader)
-struct Candidate;
-// Leader -> Follower
-struct Leader;
-
 impl<L, M> Raft<L, M, Candidate>
-where L: PersistentLog, M: StateMachine {
+    where L: PersistentLog, M: StateMachine
+{
     pub fn new(log: L, machine: M) -> Self {
         Raft {
             persistent_log: log,
             state_machine: machine,
-            state: Candidate,
-        }
-    }
-    #[cfg(test)]
-    pub fn to_follower(self) -> Raft<L, M, Follower> {
-        self.into()
-    }
-}
-
-impl<L, M> Into<Raft<L, M, Follower>> for Raft<L, M, Candidate>
-where L: PersistentLog, M: StateMachine {
-    fn into(self) -> Raft<L, M, Follower> {
-        Raft {
-            persistent_log: self.persistent_log,
-            state_machine: self.state_machine,
-            state: Follower,
+            state: ::std::marker::PhantomData,
         }
     }
 }
 
-impl<L, M> Into<Raft<L, M, Leader>> for Raft<L, M, Candidate>
-where L: PersistentLog, M: StateMachine {
-    fn into(self) -> Raft<L, M, Leader> {
-        Raft {
-            persistent_log: self.persistent_log,
-            state_machine: self.state_machine,
-            state: Leader,
-        }
-    }
+macro_rules! raft_states {
+    // hardcoded for a single #[doc = "oneline documentation"] for simplicity
+    ($(#[$attr:meta] $from:ident -> $($to:ident)|*),* $(,)*) => { $(
+        #[$attr] pub enum $from {}
+        $(
+            impl<L, M> Into<Raft<L, M, $to>> for Raft<L, M, $from>
+                where L: PersistentLog, M: StateMachine
+            {
+                fn into(self) -> Raft<L, M, $to> {
+                    Raft {
+                        persistent_log: self.persistent_log,
+                        state_machine: self.state_machine,
+                        state: ::std::marker::PhantomData,
+                    }
+                }
+            }
+        )*
+    )*}
 }
 
-impl<L, M> Into<Raft<L, M, Candidate>> for Raft<L, M, Follower>
-where L: PersistentLog, M: StateMachine {
-    fn into(self) -> Raft<L, M, Candidate> {
-        Raft {
-            persistent_log: self.persistent_log,
-            state_machine: self.state_machine,
-            state: Candidate,
-        }
-    }
+raft_states!{
+    /// Candidate: may become either a follower or a leader
+    Candidate -> Follower | Leader,
+    /// Follower: is currently following a leader
+    Follower  -> Candidate,
+    /// Leader: is the current leader
+    Leader    -> Candidate,
+}
+
+pub enum RaftState<L, M>
+    where L: PersistentLog, M: StateMachine
+{
+    Candidate(Raft<L, M, Candidate>),
+    Follower(Raft<L, M, Follower>),
+    Leader(Raft<L, M, Leader>),
 }
 
 #[cfg(test)]
 mod test {
     use persistent_log::mock::MockPersistentLog;
     use state_machine::mock::MockStateMachine;
-    use super::{Raft, Follower, Leader, Candidate};
+    use {Raft, Candidate, Follower, Leader, RaftState};
 
-    fn transitions() {
-        let persistent_log = MockPersistentLog::new();
-        let state_machine = MockStateMachine::new();
-        let raft: Raft<MockPersistentLog, MockStateMachine, Candidate> = Raft::new(persistent_log, state_machine);
-        let raft: Raft<MockPersistentLog, MockStateMachine, Follower> = raft.into();
-        let raft: Raft<MockPersistentLog, MockStateMachine, Candidate> = raft.into();
-        let raft: Raft<MockPersistentLog, MockStateMachine, Leader> = raft.into();
+    #[test]
+    fn transitions_stack() {
+        let persistent_log = MockPersistentLog::default();
+        let state_machine = MockStateMachine::default();
+        let raft: Raft<_, _, Candidate> = Raft::new(persistent_log, state_machine);
+        let raft: Raft<_, _, Follower> = raft.into();
+        let raft: Raft<_, _, Candidate> = raft.into();
+        let _raft: Raft<_, _, Leader> = raft.into();
+    }
 
+    #[test]
+    fn transitions_enum() {
+        macro_rules! assert_trans {
+            ($query:expr, $pat:pat => $expr:expr) => {
+                match $query {
+                    $pat => $expr,
+                    _ => unreachable!()
+                }
+            }
+        }
+        let persistent_log = MockPersistentLog::default();
+        let state_machine = MockStateMachine::default();
+        let mut state = RaftState::Candidate(Raft::new(persistent_log, state_machine));
+        state = assert_trans!(state, RaftState::Candidate(r) => RaftState::Follower(r.into()));
+        state = assert_trans!(state, RaftState::Follower(r) => RaftState::Candidate(r.into()));
+        state = assert_trans!(state, RaftState::Candidate(r) => RaftState::Leader(r.into()));
+        // assert is now Leader
+        assert_trans!(state, RaftState::Leader(_) => ());
     }
 }

--- a/src/state_machine/mock.rs
+++ b/src/state_machine/mock.rs
@@ -1,9 +1,6 @@
 use super::StateMachine;
 
+#[derive(Default)]
 pub struct MockStateMachine;
-impl MockStateMachine {
-    pub fn new() -> Self {
-        MockStateMachine
-    }
-}
+
 impl StateMachine for MockStateMachine {}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -6,8 +6,8 @@ use raft::state_machine::mock::MockStateMachine;
 
 #[test]
 fn creation() {
-    let persistent_log = MockPersistentLog::new();
-    let state_machine = MockStateMachine::new();
+    let persistent_log = MockPersistentLog::default();
+    let state_machine = MockStateMachine::default();
 
-    let raft = Raft::new(persistent_log, state_machine);
+    let _raft = Raft::new(persistent_log, state_machine);
 }


### PR DESCRIPTION
- No warnings with either stable Rust, nor nightly-clippy
